### PR TITLE
debug -> verbose logs

### DIFF
--- a/Dalamud.LoadingImage/LoadingImagePlugin.cs
+++ b/Dalamud.LoadingImage/LoadingImagePlugin.cs
@@ -165,8 +165,8 @@ namespace Dalamud.LoadingImage
             var unitBase = (AtkUnitBase*) _gameGui.GetAddonByName("_LocationTitle", 1);
             var unitBaseShort = (AtkUnitBase*) _gameGui.GetAddonByName("_LocationTitleShort", 1);
             
-            this._pluginLog.Debug($"unitbase: {(long)unitBase:X} visible: {unitBase->IsVisible}");
-            this._pluginLog.Debug($"unishort: {(long)unitBaseShort:X} visible: {unitBaseShort->IsVisible}");
+            this._pluginLog.Verbose($"unitbase: {(long)unitBase:X} visible: {unitBase->IsVisible}");
+            this._pluginLog.Verbose($"unishort: {(long)unitBaseShort:X} visible: {unitBaseShort->IsVisible}");
 
             if (unitBase != null && unitBaseShort != null)
             {


### PR DESCRIPTION
Assuming you are in the dalamud discord and have access to #feedback: <https://discord.com/channels/581875019861328007/892131028188151808/1379081017448468600>

Someone requested logs to be in verbose rather than debug, but was too lazy to PR this two line change themselves, even though they were likely a dev, whatever.

I think this makes sense to be in verbose with how many times it logs while changing areas. I must have over a ten thousand of these logs every session.